### PR TITLE
Bugfix: 解决情绪页面报错SyntaxError: Unexpected number in JSON at position 1

### DIFF
--- a/miniprogram/pages/mood_score/index.js
+++ b/miniprogram/pages/mood_score/index.js
@@ -33,7 +33,7 @@ Page({
     }
     // Save session_id and user_id if present
     if (options.session_id) {
-        this.setData({ session_id: JSON.parse(decodeURIComponent(options.session_id)) });
+        this.setData({ session_id: options.session_id});
     }
     // if (options.user_id) {
     //     this.setData({ user_id:JSON.parse(decodeURIComponent(options.user_id)) });


### PR DESCRIPTION
报错信息

SyntaxError: Unexpected number in JSON at position 1
    at JSON.parse (<anonymous>)
    at li.onLoad (index.js? [sm]:36)
    at li.<anonymous> (WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1)
    at li.c.__callPageLifeTime__ (WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1)
    at WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1
    at WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1
    at WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1
    at WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1
    at WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1
    at WASubContext.js?t=wechat&s=1752483928331&v=3.8.0:1(env: macOS,mp,1.06.2412050; lib: 3.8.0)